### PR TITLE
Replace WebSocket API with HTTP API for issuing commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 SERVER
 ------
 
-  - Replace websocket with sync API for issuing commands
   - Websocket remains as broadcast-only for informing all clients of updates
   - "Heart beat" read and broadcast endpoint status at configurable interval to all clients
   - "Restart" signal from server to all clients; instructs to disable and reconnect in N seconds

--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -2,7 +2,6 @@
  * Common functionality shared between Devices and Sensors
  */
 function Endpoint(params) {
-  // TODO refactor out this.type
   this.type = params.type;
   this.driver = params.driver;
   this.id = params.id;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,9 @@
 var fs = require('fs')
-  , os = require('os')
-  , util = require('util')
-  , log = require('./log')
-  , WebSocketServer = require('ws').Server
+, os = require('os')
+, util = require('util')
+, log = require('./log')
+, http = require('http')
+, WebSocketServer = require('ws').Server
 
 var ssl = (process.env.SSL === 'true');
 var config = {
@@ -10,7 +11,12 @@ var config = {
   cert: process.env.SSL_CERT,
 }
 
-var ServerClass = ssl ? require('https').Server : require('http').Server;
+function errorResponse(httpCode, response) {
+  response.writeHead(httpCode);
+  response.end(http.STATUS_CODES[httpCode]);
+}
+
+var ServerClass = ssl ? require('https').Server : http.Server;
 
 function Server(app) {
   this.app = app;
@@ -29,38 +35,26 @@ util.inherits(Server, ServerClass);
 
 Server.prototype.broadcast = function(message) {
   for(var i in this.socketServer.clients) {
-		this.socketServer.clients[i].send(message);
+    this.socketServer.clients[i].send(message);
   }
 }
 
 Server.prototype.createSocketServer = function(callback) {
-  var self = this;
   this.listen(process.env.PORT, function() {
-    self.socketServer = new WebSocketServer({ server: self })
-    self.socketServer.on('connection', self.socketConnection.bind(self));
+    this.socketServer = new WebSocketServer({ server: this })
+    this.socketServer.on('connection', this.socketConnection.bind(this));
     if ('function' === typeof callback) callback();
-  });
+  }.bind(this));
 };
 
 Server.prototype.socketConnection = function(client) {
-  var self = this;
   client.on('message', function(message) {
     if (!message) {
       return client.send(
         JSON.stringify({'type': 'error', 'message': 'Invalid server message'})
       );
     }
-    
-    try {
-      self.app.executeInstruction(JSON.parse(message)).then(function(result) {
-        client.send(JSON.stringify({'type' : 'success', 'data' : result }));
-      }).catch(function(error) {
-        client.send(JSON.stringify({'type' : 'error', 'message' : error.message }));
-      });
-    } catch(error) {
-      client.send(JSON.stringify({'type' : 'error', 'message' : error.message }));
-    }
-  });
+  }.bind(this));
 };
 
 // TODO more useful data, connection count etc
@@ -75,15 +69,65 @@ Server.prototype.status = function() {
 Server.prototype.requestHandler = function(req, res) {
   switch (req.url) {
     case '/status':
-      res.setHeader('Content-Type', 'application/json');
-      res.writeHead(200);
-      res.end(JSON.stringify(this.status()));
+      return this.statusAction(req, res);
+    break;
+
+    case '/command':
+      return this.commandAction(req, res);
     break;
 
     default:
-      res.writeHead(401);
-      res.end('BLARGH!');
+      return errorResponse(404, res);
   }
+};
+
+//
+// Return system status
+//
+Server.prototype.statusAction = function(request, response) {
+  response.setHeader('Content-Type', 'application/json');
+  response.writeHead(200);
+  response.end(JSON.stringify(this.status()));
+};
+
+//
+// Validate and execute an app command
+//
+Server.prototype.commandAction = function(request, response) {
+  if (request.method !== 'POST') {
+    return errorResponse(405, response);
+  }
+
+  var body = '';
+  request.setEncoding('utf8');
+  request.on('data', function (chunk) {
+    body += chunk;
+
+    if (body.length > 1e6) {
+      errorResponse(413, response);
+      request.connection.destroy();
+    }
+  })
+
+  // the end event tells you that you have entire body
+  request.on('end', function () {
+    try {
+      this.app.executeInstruction(JSON.parse(body))
+        .then(function(result) {
+          response.writeHead(200, {
+            'Content-type' : 'application/json' 
+          });
+          response.end(
+            JSON.stringify({'data' : result })
+          );
+        }).catch(function(error) {
+          response.writeHead(400);
+          response.end(error.message);
+        });
+    } catch(error) {
+      return errorResponse(417, response);
+    }
+  }.bind(this));
 };
 
 module.exports = Server;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "owjs": "0.1.x",
     "ws": "~0.4.31",
     "envc": "~1.0.0",
-    "bluebird": "~1.2.4"
+    "bluebird": "~1.2.4",
+    "jwt-simple": "~0.2.0"
   },
   "devDependencies": {
     "chai": "1.8.x",


### PR DESCRIPTION
The WebSocket API was a bad match for issuing endpoint commands. It was painful to use and painful to test.
